### PR TITLE
Use single postgres for replicas in ansible

### DIFF
--- a/ansible/roles/iroha-docker/tasks/init-vars.yml
+++ b/ansible/roles/iroha-docker/tasks/init-vars.yml
@@ -27,8 +27,14 @@
       iroha_peers_map: "{{ iroha_peers_map }} + [ {{ {'hostname': item, 'human_hostname': 'c_' + item | regex_replace('\\.', '_') | regex_replace(':', '_'), 'peer_port': item.split(':')[1] } }} ]"
     loop: "{{ iroha_nodes }}"
 
+  - set_fact:
+      iroha_inventory_human_hostname: "{{ 'c_' + inventory_hostname | regex_replace('\\.', '_') }}"
+
   - debug:
       var: iroha_peers_map
+
+  - debug:
+      var: iroha_inventory_human_hostname
 
   - set_fact:
       iroha_nodes: "{{ iroha_peers_map }}"

--- a/ansible/roles/iroha-docker/templates/config.docker.j2
+++ b/ansible/roles/iroha-docker/templates/config.docker.j2
@@ -2,7 +2,7 @@
   "block_store_path" : "{{ iroha_blockstore_path }}",
   "torii_port" : {{ iroha_torii_port }},
   "internal_port" : {{ iroha_peer_port }},
-  "pg_opt" : "host={{ item.human_hostname }}-postgres port={{ iroha_postgres_port }} user={{ iroha_postgres_user }} password={{ iroha_postgres_password }}",
+  "pg_opt" : "host={{ iroha_inventory_human_hostname }}-postgres port={{ iroha_postgres_port }} user={{ iroha_postgres_user }} password={{ iroha_postgres_password }} dbname={{ item.human_hostname }}",
   "max_proposal_size" : {{ iroha_max_proposal_size }},
   "proposal_delay" : {{ iroha_proposal_delay }},
   "vote_delay" : {{ iroha_vote_delay }},

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -18,26 +18,28 @@ services:
 {% endif %}
     environment:
       KEY: {{ node.hostname }}
-      IROHA_POSTGRES_HOST: {{ node.human_hostname }}-postgres
+      IROHA_POSTGRES_HOST: {{ iroha_inventory_human_hostname }}-postgres
     volumes:
       - iroha_block_store-{{ node.human_hostname }}:/tmp/block_store
       - ./conf/{{ node.human_hostname }}:/opt/iroha_data
     depends_on:
-      - {{ node.human_hostname }}-postgres
+      - {{ iroha_inventory_human_hostname }}-postgres
     networks:
       - {{ iroha_network_name }}
       - iroha-db-net
     restart: always
 
-  {{ node.human_hostname }}-postgres:
+{% endfor %}
+
+  {{ iroha_inventory_human_hostname }}-postgres:
     image: postgres:{{ iroha_postgres_docker_tag }}
-    container_name: {{ node.human_hostname }}-postgres
+    container_name: {{ iroha_inventory_human_hostname }}-postgres
     environment:
       POSTGRES_PASSWORD: {{ iroha_postgres_password }}
     expose:
       - {{ iroha_postgres_port }}
     volumes:
-      - psql_storage-{{ node.human_hostname }}:/var/lib/postgresql/data
+      - psql_storage-{{ iroha_inventory_human_hostname }}:/var/lib/postgresql/data
     networks:
       - iroha-db-net
     restart: always
@@ -45,13 +47,11 @@ services:
     command: -c max_prepared_transactions={{ iroha_postgres_max_prepared_transactions }}
 {% endif %}
 
-{% endfor %}
-
 volumes:
 {% for node in iroha_nodes %}
   iroha_block_store-{{ node.human_hostname }}:
-  psql_storage-{{ node.human_hostname }}:
 {% endfor %}
+  psql_storage-{{ iroha_inventory_human_hostname }}:
 
 networks:
   {{ iroha_network_name }}:


### PR DESCRIPTION
Reopened https://github.com/hyperledger/iroha/pull/28

### Description of the Change
Share a single container with postgres for all the replicas deployed on a single machine. This change allows to use an external service, such as postgres_exporter, to be used when multiple replicas are deployed since statistics collection for a single machine is centralized (port 5432 is used).

### Benefits
Less containers deployed, easier statistics collection, simpler memory management for postgres (can specify mem_limit for all the instances).

### Possible Drawbacks 
Greater coupling - failure of a single container will affect multiple Iroha nodes.

### Alternate Designs
Add conditional deployment that will allow both usages, with multiple postgres instances, and with a single instance.