### PR TITLE
Fix Docker Compose network creation scenarios

### DIFF
--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -34,7 +34,9 @@ services:
     depends_on:
       - {{ iroha_inventory_human_hostname }}-postgres
     networks:
+{% if iroha_custom_hostnames and not iroha_overlay_network %}
       - {{ iroha_network_name }}
+{% endif %}
       - iroha-db-net
     logging:
       driver: "json-file"
@@ -71,8 +73,10 @@ volumes:
   psql_storage-{{ iroha_inventory_human_hostname }}:
 
 networks:
+{% if iroha_custom_hostnames and not iroha_overlay_network %}
   {{ iroha_network_name }}:
     external:
       name: {{ iroha_network_name }}
+{% endif %}
   iroha-db-net:
     name: iroha-db-net


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

Fixes redundant creation of a Docker Compose network for a particular scenario with custom hostnames and Docker bridge network (`not iroha_overlay_network`). In that case other hosts are available via this bridge, a separate network is not required.