### PR TITLE
DOPS-614: Refactoring Iroha Ansible role

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -34,7 +34,7 @@ display_skipped_hosts	= false
 
 
 # Default strategy
-strategy		= free
+strategy		= linear
 
 # Make some actions faster with loops
 #squash_actions = apk,apt,dnf,homebrew,package,pacman,pkgng,yum,zypper

--- a/ansible/playbooks/iroha-docker/main.yml
+++ b/ansible/playbooks/iroha-docker/main.yml
@@ -2,5 +2,3 @@
   strategy: linear
   roles:
     - { role: iroha-docker, tags: iroha-docker }
-  vars:
-    iroha_hostnames: []

--- a/ansible/playbooks/iroha-docker/main.yml
+++ b/ansible/playbooks/iroha-docker/main.yml
@@ -1,4 +1,5 @@
 - hosts: all
+  # we need to use linear strategy, because some variables are set in runtime
   strategy: linear
   roles:
     - { role: iroha-docker, tags: iroha-docker }

--- a/ansible/roles/iroha-docker/README.md
+++ b/ansible/roles/iroha-docker/README.md
@@ -93,8 +93,51 @@ Deploying 6 Iroha peers on two remote hosts communicating using public IP addres
 ```
 ansible-playbook -i inventory/iroha.list -b playbooks/iroha-docker/main.yml
 ```
-
 **Example 2**
+Deploying 3 Iroha peers on two remote hosts communicating using DNS name. With 2 and 1 replicas on each host respectively.
+We will use pivate ip (`192.168.122.109, 192.168.122.30`) to connect and deploy Iroha and we will use DNS name (`iroha[1-3].example.com`) to communicate between peers.
+
+1. Create inventory list containing IP addresses (or hostnames) of two hosts that will run Iroha peers.
+
+    **iroha.list**
+    ```
+    [all]
+    192.168.122.109
+    192.168.122.30
+    ```
+
+    Put this file into `../../inventory/` directory.
+
+2. Make sure you can SSH with a root account into either of these hosts using a private key.
+
+    **Note**
+    > You can also SSH with the user other than root. Make sure it can execute `sudo` without prompting for a password. Set `-u` option for `ansible-playbook` command.
+
+3. Create two YAML files in `../playbooks/iroha-docker/host_vars` directory:
+    **192.168.122.109.yml**
+    ```
+    iroha_replicas: 2
+    iroha_service_host: True
+    # this is account and private key from example genesis.block
+    iroha_service_account: admin@test
+    iroha_service_account_keys: [ 'f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70' ]
+    iroha_custom_hostnames: true
+    iroha_hostnames: ["iroha1.example.com:10001","iroha2.example.com:10002"] # we use different port because both replica are in one server
+    ```
+
+    **192.168.122.30.yml**
+    ```
+    iroha_replicas: 1
+    iroha_custom_hostnames: true
+    iroha_hostnames: ["iroha3.example.com:10001"]
+    ```
+
+ 4. Run the playbook
+```
+ansible-playbook -i inventory/iroha.list -b playbooks/iroha-docker/main.yml
+```
+
+**Example 3**
 Deploying 6 Iroha peers on two remote hosts communicating over overlay network (Calico) using custom hostnames.
 
 **TBD**

--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -19,23 +19,23 @@ iroha_forced_cleaning: False
 iroha_custom_hostnames: false
 
 # Affects how Iroha peers are communicated.
-# If set to `internal` Iroha will use docker network to communicate between nodes
-# If set to `overlay` Iroha will create docker overlay network to communicate between node.
-# If set to `external` Iroha will map port to host and will use it to communicate..
+# If set to `internal` Iroha will use docker bridge network to communicate between nodes. You can only use this mode if you want to deploy all nodes on one host  
+# If set to `overlay` Iroha will create a docker overlay network to communicate between node.
+# If set to `external` Iroha will map the port to host and will use it to communicate. Overlay network plugin (like Calico) or docker swarm should be enabled on all host.
 #
 # Default: external
 iroha_network: external
+# Docker network name
+# The network will be created automatically.
+iroha_network_name: iroha-net
+# Overlay network settings
+iroha_network_address: '10.10.111.0/24'
+iroha_network_gateway: '10.10.111.1'
 
 ## Deployment configs
 iroha_container_basename: iroha
 # Path on a remote machine for generated configs
 iroha_deploy_dir: /opt/iroha-deploy
-# Overlay network name
-# If using overlay network plugin (like Calico) the network must be created prior running this role
-# The network will be created automatically if deploying with `iroha_network` set to `external` or `internal`
-iroha_network_name: iroha-net
-iroha_network_address: '10.10.111.0/24'
-iroha_network_gateway: '10.10.111.1'
 
 # The role is incompatible with Iroha versions below RC2 since keys format has changed.
 # Apply the patch (files/old-keys-format.patch) if you need support for previous Iroha versions.

--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -18,15 +18,13 @@ iroha_forced_cleaning: False
 # Default: false
 iroha_custom_hostnames: false
 
-# Affects how Iroha peers are communicated. If set to `true`, Docker overlay network with that
-# name will be used. It must be created beforehand. The recommended way is to use Swarm cluster
-# or create a network manually using a KV storage.
-# Setting it to `true` without creating the network will only work for a single host deployment
-# (Iroha peers will only be able to communicate within that host). Suitable for local-only
-# deployments for testing purposes.
+# Affects how Iroha peers are communicated.
+# If set to `internal` Iroha will use docker network to communicate between nodes
+# If set to `overlay` Iroha will create docker overlay network to communicate between node.
+# If set to `external` Iroha will map port to host and will use it to communicate..
 #
-# Default: false
-iroha_overlay_network: false
+# Default: external
+iroha_network: external
 
 ## Deployment configs
 iroha_container_basename: iroha
@@ -34,8 +32,7 @@ iroha_container_basename: iroha
 iroha_deploy_dir: /opt/iroha-deploy
 # Overlay network name
 # If using overlay network plugin (like Calico) the network must be created prior running this role
-# The network will be created automatically if deploying locally or with `iroha_overlay_network`
-# set to `false`
+# The network will be created automatically if deploying with `iroha_network` set to `external` or `internal`
 iroha_network_name: iroha-net
 iroha_network_address: '10.10.111.0/24'
 iroha_network_gateway: '10.10.111.1'

--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -11,7 +11,7 @@ iroha_forced_cleaning: False
 
 # Whether to use custom hostname for EACH container.
 # If set to `true`, Iroha peers will communicate using these hostnames. Hostnames should be set using
-# `iroha_hostnames` variable. See example playbook in `playbooks/iroha-docker/main.yml`.
+# `iroha_hostnames` variable. See example in `ansible/roles/iroha-docker/README.md `.
 # If set to `false`, Iroha peers will communicate by IP addresses set by `inventory_hostname`
 # variable. Container and service names in Docker Compose files will be auto-generated.
 #
@@ -20,8 +20,8 @@ iroha_custom_hostnames: false
 
 # Affects how Iroha peers are communicated.
 # If set to `internal` Iroha will use docker bridge network to communicate between nodes. You can only use this mode if you want to deploy all nodes on one host  
-# If set to `overlay` Iroha will create a docker overlay network to communicate between node.
-# If set to `external` Iroha will map the port to host and will use it to communicate. Overlay network plugin (like Calico) or docker swarm should be enabled on all host.
+# If set to `overlay` Iroha will create a docker overlay network to communicate between node. Overlay network plugin (like Calico) or docker swarm should be enabled on all host.
+# If set to `external` Iroha will map the port to host system and will use it to communicate.
 #
 # Default: external
 iroha_network: external

--- a/ansible/roles/iroha-docker/tasks/check.yml
+++ b/ansible/roles/iroha-docker/tasks/check.yml
@@ -1,7 +1,7 @@
-# tasks in this file check that role can be aplaid to hosts
+# tasks in this file check that role can be applied to hosts
 
 - block:
-  - name: check | check for deprecated varible
+  - name: check | check for deprecated variable
     fail:
       msg: "iroha_overlay_network is deprecated use: 'iroha_network'"
     when: iroha_overlay_network is defined
@@ -13,7 +13,7 @@
 
   - name: check | check iroha_network
     fail:
-      msg: "You can not use iroha_network == 'internal' if you have more when one host"
+      msg: "You can not use iroha_network == 'internal' if you have more than one host"
     when: iroha_network == 'internal' and ansible_play_hosts | length > 1
 
   - name: Check | Stop playbook if one host fail

--- a/ansible/roles/iroha-docker/tasks/check.yml
+++ b/ansible/roles/iroha-docker/tasks/check.yml
@@ -1,0 +1,23 @@
+# tasks in this file check that role can be aplaid to hosts
+
+- block:
+  - name: check | check for deprecated varible
+    fail:
+      msg: "iroha_overlay_network is deprecated use: 'iroha_network'"
+    when: iroha_overlay_network is defined
+
+  - name: check | check iroha_hostnames length and iroha_replicas
+    fail:
+      msg: "'iroha_hostnames' length ({{ iroha_hostnames|length }}) should match the 'iroha_replicas' ({{ iroha_replicas }})"
+    when: iroha_custom_hostnames and iroha_hostnames is defined and iroha_hostnames | length != iroha_replicas
+
+  - name: check | check iroha_network
+    fail:
+      msg: "You can not use iroha_network == 'internal' if you have more when one host"
+    when: iroha_network == 'internal' and ansible_play_hosts | length > 1
+
+  - name: Check | Stop playbook if one host fail
+    meta: end_play
+    when: ansible_play_hosts_all != ansible_play_hosts
+
+  tags: ["iroha-docker", "iroha-check"]

--- a/ansible/roles/iroha-docker/tasks/deploy.yml
+++ b/ansible/roles/iroha-docker/tasks/deploy.yml
@@ -3,13 +3,13 @@
   # Attachable overlay network cannot be created with a `docker_network` module
   - name: Create Docker network 1
     shell: "docker network create -d overlay --attachable {{ iroha_network_name }} --gateway {{ iroha_network_gateway }} --subnet {{ iroha_network_address }} || true"
-    when: iroha_overlay_network and (ansible_play_batch | length > 1)
+    when: iroha_network == 'overlay'
     run_once: yes
 
   - name: Create Docker network 2
     docker_network:
       name: "{{ iroha_network_name }}"
-    when: not iroha_overlay_network or (ansible_play_batch | length == 1)
+    when: iroha_network != 'overlay'
 
   - name: Generate Docker Compose file
     template:

--- a/ansible/roles/iroha-docker/tasks/init-vars.yml
+++ b/ansible/roles/iroha-docker/tasks/init-vars.yml
@@ -3,21 +3,21 @@
       iroha_nodes: []
       iroha_peers_map: []
 
-  - name: Generate hostnames (no overlay)
+  - name: Generate hostnames (external)
     set_fact:
       iroha_nodes: "{{ iroha_nodes }} + [ '{{ inventory_hostname }}:{{ iroha_peer_port | int + item | int }}' ]"
     loop: "{{ range(0, iroha_replicas |int) | list }}"
-    when: not iroha_custom_hostnames and not iroha_overlay_network
+    when: not iroha_custom_hostnames and iroha_network == 'external'
 
-  - name: Generate hostnames (overlay)
+  - name: Generate hostnames (overlay/internal)
     set_fact:
       iroha_nodes: "{{ iroha_nodes }} + [ '{{ iroha_container_basename }}-{{ item }}-{{ inventory_hostname | checksum | regex_replace('(^[a-fA-F0-9]{8}).+$', '\\1') }}:{{ iroha_peer_port }}' ]"
     loop: "{{ range(0, iroha_replicas) | list }}"
-    when: not iroha_custom_hostnames and iroha_overlay_network
+    when: not iroha_custom_hostnames and iroha_network != 'external'
 
   - name: Generate hostnames (iroha_custom_hostnames)
     set_fact:
-      iroha_nodes: "{{ iroha_nodes }} + [ '{% if item.split(':') | length < 2 %}{{ item }}:{% if iroha_overlay_network %}{{ iroha_peer_port }}{% else %}{{ iroha_peer_port | int + idx }}{% endif %}{% else %}{{ item }}{% endif %}' ]"
+      iroha_nodes: "{{ iroha_nodes }} + [ '{% if item.split(':') | length < 2 %}{{ item }}:{% if iroha_network != 'external' %}{{ iroha_peer_port }}{% else %}{{ iroha_peer_port | int + idx }}{% endif %}{% else %}{{ item }}{% endif %}' ]"
     when: iroha_custom_hostnames and iroha_hostnames is defined
     loop: "{{ iroha_hostnames }}"
     loop_control:

--- a/ansible/roles/iroha-docker/tasks/main.yml
+++ b/ansible/roles/iroha-docker/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Iroha check
+  include: check.yml
+
 - name: Iroha clean
   include: clean.yml
 

--- a/ansible/roles/iroha-docker/tasks/manual-keys.yml
+++ b/ansible/roles/iroha-docker/tasks/manual-keys.yml
@@ -30,7 +30,7 @@
 
 - name: Set 'iroha_invalid_peer_list' variable 1
   set_fact:
-    iroha_invalid_peer_list: "{{ iroha_nodes | difference(iroha_peer_keys_from_file[inventory_hostname].keys()) | default([]) }}"
+    iroha_invalid_peer_list: "{{ iroha_nodes | difference((iroha_peer_keys_from_file[inventory_hostname] | default({})).keys()) | default([]) }}"
   when: iroha_peer_keys_from_file is defined
 
 - name: Set 'iroha_invalid_peer_list' variable 2
@@ -66,7 +66,7 @@
 
 - name: Generate peer keys
   docker_container:
-    name: "iroha_command_for_{{ ansible_host }}"
+    name: "iroha_command_{{ 999999 | random }}"
     image: "iroha-docker-iroha-python"
     recreate: yes
     detach: no
@@ -89,7 +89,7 @@
 
   - name: Encrypt peer keys
     docker_container:
-      name: "iroha_command_for_{{ ansible_host }}"
+      name: "iroha_command_{{ 999999 | random }}"
       image: "iroha-docker-iroha-python"
       recreate: yes
       detach: no

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -4,14 +4,14 @@ services:
 {% for node in iroha_nodes %}
   {{ node.human_hostname }}:
     image: hyperledger/iroha:{{ iroha_docker_tag }}
-{% if iroha_overlay_network %}
+{% if iroha_network != 'external' %}
     container_name: {{ node.hostname.split(':')[0] }}
     expose:
       - {{ iroha_peer_port }}
     ports:
       - {{ iroha_torii_port | int + loop.index - 1 }}:{{ iroha_torii_port }}
 {% else %}
-    container_name: {{ node.human_hostname }}
+    container_name: {{ iroha_container_basename }}-{{ node.human_hostname }}
     ports:
       - {{ node.peer_port }}:{{ iroha_peer_port }}
       - {{ iroha_torii_port | int + loop.index - 1 }}:{{ iroha_torii_port }}


### PR DESCRIPTION
1. fix docker network, now we can separate overlay and internal network logic, it should fix  https://github.com/hyperledger/iroha-deploy/pull/9
2. Add check task, they run before all task and check if configurations are correct.
3. changed iroha container name for external network:
  `'c_10_10_10_3_10001' ->  'iroha-c_10_10_10_3_10001'`
4. fixes of small bags
