### PR TITLE
DOPS-633 update iroha role

### DIFF
--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -40,7 +40,7 @@ iroha_deploy_dir: /opt/iroha-deploy
 # The role is incompatible with Iroha versions below RC2 since keys format has changed.
 # Apply the patch (files/old-keys-format.patch) if you need support for previous Iroha versions.
 
-iroha_pull_image_var: yes
+iroha_docker_image_pull: true
 iroha_docker_image: 'hyperledger/iroha'
 iroha_docker_tag: '1.1.0'
 

--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -39,7 +39,10 @@ iroha_deploy_dir: /opt/iroha-deploy
 
 # The role is incompatible with Iroha versions below RC2 since keys format has changed.
 # Apply the patch (files/old-keys-format.patch) if you need support for previous Iroha versions.
+iroha_docker_image: 'hyperledger/iroha'
 iroha_docker_tag: '1.1.0'
+
+iroha_postgres_docker_image: 'postgres' 
 iroha_postgres_docker_tag: '9.5'
 
 ## Iroha config
@@ -51,7 +54,7 @@ iroha_peer_port: 10001
 iroha_torii_port: 50051
 # Enables 2 phase commit optimization. Postgres documentation suggests setting it to a max number of
 # connections, which is 100 by default
-iroha_postgres_max_prepared_transactions: 100
+iroha_postgres_commands: '-c max_prepared_transactions=100'
 
 # Rest of the options affect Iroha configuration
 # See https://iroha.readthedocs.io/en/latest/guides/configuration.html#configuration
@@ -72,8 +75,10 @@ iroha_blockstore_path: /tmp/block_store
 ## Custom Docker configuration
 # Docker container environment variables
 iroha_docker_env_variables: {}
-# Docker container labels
+# Docker iroha container labels
 iroha_docker_labels: {}
+# Docker postgres container labels
+postgres_docker_labels: {}
 
 ## Iroha logging
 # Maximum docker log file size

--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -39,6 +39,8 @@ iroha_deploy_dir: /opt/iroha-deploy
 
 # The role is incompatible with Iroha versions below RC2 since keys format has changed.
 # Apply the patch (files/old-keys-format.patch) if you need support for previous Iroha versions.
+
+iroha_pull_image_var: yes
 iroha_docker_image: 'hyperledger/iroha'
 iroha_docker_tag: '1.1.0'
 

--- a/ansible/roles/iroha-docker/handlers/main.yml
+++ b/ansible/roles/iroha-docker/handlers/main.yml
@@ -3,6 +3,6 @@
 - name: restart Iroha
   docker_compose:
     project_src: "{{ iroha_deploy_dir }}"
-    pull: yes
+    pull: "{{ iroha_pull_image_var }}"
     state: present
     recreate: always

--- a/ansible/roles/iroha-docker/handlers/main.yml
+++ b/ansible/roles/iroha-docker/handlers/main.yml
@@ -3,6 +3,6 @@
 - name: restart Iroha
   docker_compose:
     project_src: "{{ iroha_deploy_dir }}"
-    pull: "{{ iroha_pull_image_var }}"
+    pull: "{{ iroha_docker_image_pull }}"
     state: present
     recreate: always

--- a/ansible/roles/iroha-docker/tasks/check.yml
+++ b/ansible/roles/iroha-docker/tasks/check.yml
@@ -5,7 +5,10 @@
     fail:
       msg: "iroha_overlay_network is deprecated use: 'iroha_network'"
     when: iroha_overlay_network is defined
-
+  - name:
+    fail:
+      msg: "'iroha_postgres_max_prepared_transactions' variable is depricated, use: 'iroha_postgres_commands'"
+    when: iroha_postgres_max_prepared_transactions is defined
   - name: check | check iroha_hostnames length and iroha_replicas
     fail:
       msg: "'iroha_hostnames' length ({{ iroha_hostnames|length }}) should match the 'iroha_replicas' ({{ iroha_replicas }})"

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -3,7 +3,7 @@ version: "2.4"
 services:
 {% for node in iroha_nodes %}
   {{ node.human_hostname }}:
-    image: hyperledger/iroha:{{ iroha_docker_tag }}
+    image: {{ iroha_docker_image }}:{{ iroha_docker_tag }}
 {% if iroha_network != 'external' %}
     container_name: {{ node.hostname.split(':')[0] }}
     expose:
@@ -49,19 +49,25 @@ services:
 {% endfor %}
 
   {{ iroha_inventory_human_hostname }}-postgres:
-    image: postgres:{{ iroha_postgres_docker_tag }}
+    image: {{ iroha_postgres_docker_image }}:{{ iroha_postgres_docker_tag }}
     container_name: {{ iroha_inventory_human_hostname }}-postgres
     environment:
       POSTGRES_PASSWORD: {{ iroha_postgres_password }}
     expose:
       - {{ iroha_postgres_port }}
+{% if postgres_docker_labels %}
+    labels:
+{% for label in postgres_docker_labels.items() %}
+      - "{{ label[0] }}={{ label[1] }}"
+{% endfor %}
+{% endif %}
     volumes:
       - psql_storage-{{ iroha_inventory_human_hostname }}:/var/lib/postgresql/data
     networks:
       - iroha-db-net
     restart: always
-{% if iroha_postgres_max_prepared_transactions is defined %}
-    command: -c max_prepared_transactions={{ iroha_postgres_max_prepared_transactions }}
+{% if iroha_postgres_commands is defined %}
+    command: {{ iroha_postgres_commands }}
 {% endif %}
 
 volumes:


### PR DESCRIPTION
Changes:
1. Currently we can add docker label for iroha `iroha_docker_labels`,
added same options for postgres container. `iroha_postgres_docker_labels`

2. Currently  the postgres can be run only with one option: 
```
command: -c max_prepared_transactions={{ iroha_postgres_max_prepared_transactions }}
```
This is not ideal, in future we may want to tune the postgres, which will require to add a lot of postgres options. 
we changed it to:
```
    command: {{ iroha_postgres_commands }}
```
where:
```
iroha_postgres_commands: '-c max_prepared_transactions=100' 
```

3. One may want to use custom build iroha docker image, this two variable allow it:
```
iroha_docker_image: 'hyperledger/iroha'
iroha_postgres_docker_image: 'postgres' 
```