### PR TITLE
add custom config params

### DIFF
--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -75,6 +75,22 @@ iroha_blockstore_path: /tmp/block_store
 #iroha_mst_expiration_time: 1440
 #iroha_max_rounds_delay: 3000
 #iroha_stale_stream_max_rounds: 2
+#iroha_custom_config_params: '
+#"log": {
+#  "level": "info",
+#  "children": {
+#    "Irohad": {
+#      "children": {
+#        "Consensus": {
+#          "level": "warning"
+#        },
+#        "Synchronizer": {
+#          "level": "warning"
+#        }
+#      }
+#    }
+#  }
+#}'
 
 ## Custom Docker configuration
 # Docker container environment variables
@@ -82,7 +98,7 @@ iroha_docker_env_variables: {}
 # Docker iroha container labels
 iroha_docker_labels: {}
 # Docker postgres container labels
-postgres_docker_labels: {}
+iroha_postgres_docker_labels: {}
 
 ## Iroha logging
 # Maximum docker log file size

--- a/ansible/roles/iroha-docker/tasks/check.yml
+++ b/ansible/roles/iroha-docker/tasks/check.yml
@@ -19,6 +19,11 @@
       msg: "You can not use iroha_network == 'internal' if you have more than one host"
     when: iroha_network == 'internal' and ansible_play_hosts | length > 1
 
+  - name: check | check postgres_docker_labels
+    fail:
+      msg: "postgres_docker_labels is deprecated use: 'iroha_postgres_docker_labels'"
+    when: postgres_docker_labels  is defined
+
   - name: Check | Stop playbook if one host fail
     meta: end_play
     when: ansible_play_hosts_all != ansible_play_hosts

--- a/ansible/roles/iroha-docker/templates/config.docker.j2
+++ b/ansible/roles/iroha-docker/templates/config.docker.j2
@@ -24,4 +24,7 @@
 {% if iroha_stale_stream_max_rounds is defined %}
   ,"stale_stream_max_rounds": {{ iroha_stale_stream_max_rounds }}
 {% endif %}
+{% if iroha_custom_config_params is defined %}
+  ,{{ iroha_custom_config_params }}
+{% endif %}
 }

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -28,7 +28,7 @@ services:
 {% endfor %}
 {% if iroha_docker_labels %}
     labels:
-{% for label in iroha_docker_labels.items() %}
+{% for label in iroha_docker_labels.items() | sort %}
       - "{{ label[0] }}={{ label[1] }}"
 {% endfor %}
 {% endif %}
@@ -59,9 +59,9 @@ services:
       POSTGRES_PASSWORD: {{ iroha_postgres_password }}
     expose:
       - {{ iroha_postgres_port }}
-{% if postgres_docker_labels %}
+{% if iroha_postgres_docker_labels %}
     labels:
-{% for label in postgres_docker_labels.items() %}
+{% for label in iroha_postgres_docker_labels.items() | sort %}
       - "{{ label[0] }}={{ label[1] }}"
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>
Changes:
1. add sort on docker labels option. (fix problem: On each run docker labels order might change.)
2. rename `postgres_docker_labels` to `iroha_postgres_docker_labels`
3. Add iroha custom config params, Iroha may require complicated json config. Added options to user create  own complicated docker params. 