### PR TITLE
DOPS-988  Clean iroha-deploy role

### DIFF
--- a/ansible/roles/iroha-docker/tasks/config-gen.yml
+++ b/ansible/roles/iroha-docker/tasks/config-gen.yml
@@ -58,12 +58,12 @@
     run_once: yes
     when: not node_change and iroha_all_new_nodes
 
-  - name: Debug
-    debug:
+  - debug:
       var: iroha_new_genesis_block
     run_once: yes
     become: no
     delegate_to: localhost
+    tags: ["never"]
 
   - name: Move genesis.block
     copy:

--- a/ansible/roles/iroha-docker/tasks/deploy.yml
+++ b/ansible/roles/iroha-docker/tasks/deploy.yml
@@ -26,6 +26,10 @@
     loop: "{{ iroha_nodes }}"
     tags: ["iroha-deploy"]
 
+  - name: Flush handlers befor service start
+    meta: flush_handlers
+    tags: ["iroha-deploy"]
+
   - name: Run Iroha
     docker_compose:
       project_src: "{{ iroha_deploy_dir }}"

--- a/ansible/roles/iroha-docker/tasks/init-vars.yml
+++ b/ansible/roles/iroha-docker/tasks/init-vars.yml
@@ -35,9 +35,11 @@
 
   - debug:
       var: iroha_peers_map
+    tags: ["never"]
 
   - debug:
       var: iroha_inventory_human_hostname
+    tags: ["never"]
 
   - set_fact:
       iroha_nodes: "{{ iroha_peers_map }}"
@@ -79,6 +81,7 @@
       debug:
         var: iroha_all_new_nodes
       run_once: yes
+      tags: [ "never"]
 
     - name: Set iroha_old_nodes variable
       set_fact:
@@ -86,7 +89,8 @@
 
     - name: Set node_change variable
       set_fact:
-        node_change: "{{ iroha_all_new_nodes and (( iroha_all_new_nodes | length ) < ( iroha_all_nodes | length )) }}"
+        # if we have new node and this is not first deploy
+        node_change: "{{ (iroha_all_new_nodes | length > 0 ) and (( iroha_all_new_nodes | length ) < ( iroha_all_nodes | length ))  }}"
       run_once: yes
 
   become: no

--- a/ansible/roles/iroha-docker/tasks/manual-keys.yml
+++ b/ansible/roles/iroha-docker/tasks/manual-keys.yml
@@ -21,6 +21,7 @@
    var: iroha_peer_keys_from_file
   when: iroha_peer_keys_from_file is defined
   run_once: yes
+  tags: [ "never"]
 
 - name: Set init value for 'iroha_new_peer_keys', 'iroha_new_peer_keys_encrypt' and 'iroha_invalid_peer_list' variables
   set_fact:
@@ -40,6 +41,7 @@
 
 - debug:
     var: iroha_invalid_peer_list
+  tags: ["never"]
 
 - name: Set iroha_invalid_peer variable
   set_fact:

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -52,7 +52,7 @@ services:
 {% endif %}
     restart: always
 {% if iroha_docker_commands is defined %}
-    # Only JSON notation for commands can work in docker-compose
+    {#- Only JSON notation for commands can work in docker-compose #}
     command: {{ iroha_docker_commands | to_json }}
 {% endif %}
 
@@ -83,7 +83,7 @@ services:
       - iroha-db-net
     restart: always
 {% if iroha_postgres_commands is defined %}
-    # Only JSON notation for commands can work in docker-compose
+    {#- Only JSON notation for commands can work in docker-compose #}
     command: {{ iroha_postgres_commands | to_json }}
 {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>
# Changes:
1. Disable all debug output. Ansible logs will not spam, you still can see all debug output if run with `--tags iroha-docker`
```
ansible-playbook playbooks/iroha-docker/main.yml -b  -i inventory/iroha.yml  --tags iroha-docker | wc -l 
253
ansible-playbook playbooks/iroha-docker/main.yml -b  -i inventory/iroha.yml  | wc -l 
192
```
2. Convert yaml to jinja comment inside docker-compose file

3. Add flush handlers 

4. Remove ansible  warnings  about bool

