### PR TITLE
[DOPS-1051] Custom external networks

### DIFF
--- a/ansible/roles/iroha-docker/defaults/main.yml
+++ b/ansible/roles/iroha-docker/defaults/main.yml
@@ -31,6 +31,10 @@ iroha_network_name: iroha-net
 # Overlay network settings
 iroha_network_address: '10.10.111.0/24'
 iroha_network_gateway: '10.10.111.1'
+# If you want to connect Iroha to already existing docker network
+# set name of network to this variable
+# docker network should be created befog staring Iroha docker
+iroha_additional_docker_networks: []
 
 ## Deployment configs
 iroha_container_basename: iroha
@@ -54,6 +58,12 @@ iroha_docker_tag: '1.1.0'
 
 iroha_postgres_docker_image: 'postgres' 
 iroha_postgres_docker_tag: '9.5'
+
+# Role will create iroha-db-net to connect postgres and Iroha,
+# depend on you case you may need to connect to iroha postgres from different container.
+# you can set this variable to connect Iroha postgres to external docker network
+# docker network should be created befog staring Iroha docker
+iroha_postgres_additional_docker_networks: []
 
 # Iroha-utils docker image variables 
 iroha_util_docker_image: 'iroha-docker-iroha-python'

--- a/ansible/roles/iroha-docker/tasks/deploy.yml
+++ b/ansible/roles/iroha-docker/tasks/deploy.yml
@@ -15,6 +15,9 @@
     template:
       src: docker-compose.yml.j2
       dest: "{{ iroha_deploy_dir }}/docker-compose.yml"
+    # restart all services, (Iroha has undetermined behavior if Postgres restarts)
+    # TODO remove it after Iroha fixed
+    notify: restart Iroha
     tags: ["iroha-deploy"]
 
   - name: Generate config files

--- a/ansible/roles/iroha-docker/tasks/deploy.yml
+++ b/ansible/roles/iroha-docker/tasks/deploy.yml
@@ -15,7 +15,6 @@
     template:
       src: docker-compose.yml.j2
       dest: "{{ iroha_deploy_dir }}/docker-compose.yml"
-    notify: restart Iroha
     tags: ["iroha-deploy"]
 
   - name: Generate config files

--- a/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
+++ b/ansible/roles/iroha-docker/templates/docker-compose.yml.j2
@@ -42,6 +42,9 @@ services:
     networks:
       - {{ iroha_network_name }}
       - iroha-db-net
+{% for net in iroha_additional_docker_networks %}
+      - {{ net }}
+{%endfor%}
     logging:
       driver: "json-file"
       options:
@@ -81,6 +84,9 @@ services:
       - {{ iroha_volume_dir }}psql_storage-{{ iroha_inventory_human_hostname }}:/var/lib/postgresql/data
     networks:
       - iroha-db-net
+{% for net in iroha_postgres_additional_docker_networks %}
+      - {{ net }}
+{%endfor%}
     restart: always
 {% if iroha_postgres_commands is defined %}
     {#- Only JSON notation for commands can work in docker-compose #}
@@ -103,3 +109,8 @@ networks:
       name: {{ iroha_network_name }}
   iroha-db-net:
     name: iroha-db-net
+{% for net in ( iroha_additional_docker_networks | union(iroha_postgres_additional_docker_networks) ) %}
+  {{ net }}:
+    external:
+      name: {{ net }}
+{%endfor%}


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

1. Feature to add custom external networks, for example, we need to monitor Iroha and Postgres database.
2. Remove `notify: restart Iroha` from copy docker-compose.yml, if docker-compose is changed compose will restart it in any way, but now we restart all services inside docker-compose for any changes. 