### PR TITLE
[DOPS-1451] Fix Iroha deploy role

### DIFF
--- a/ansible/roles/iroha-docker/tasks/check.yml
+++ b/ansible/roles/iroha-docker/tasks/check.yml
@@ -24,8 +24,13 @@
       msg: "postgres_docker_labels is deprecated use: 'iroha_postgres_docker_labels'"
     when: postgres_docker_labels  is defined
 
-  - name: Check | Stop playbook if one host fail
+  - name: check | Stop playbook if one host fail
     meta: end_play
     when: ansible_play_hosts_all != ansible_play_hosts
+    
+  - name: check | Check Ansible version
+    fail:
+      msg: "Your Ansible version is incorrect. Please use Ansible version >=2.9.x"
+    when: ansible_version.full is version('2.9', '<')
 
   tags: ["iroha-docker", "iroha-check"]

--- a/ansible/roles/iroha-docker/tasks/config-gen.yml
+++ b/ansible/roles/iroha-docker/tasks/config-gen.yml
@@ -28,7 +28,7 @@
 
       - name: Get existing genesis block 2
         set_fact:
-          iroha_new_genesis_block: "{{ (iroha_command_register.ansible_facts.docker_container.Output | from_json).result }}"
+          iroha_new_genesis_block: "{{ (iroha_command_register.container.Output | from_json).result }}"
 
     delegate_to: "{{ iroha_command_host }}"
     run_once: yes
@@ -49,10 +49,11 @@
             - "{{ iroha_genesis_block | from_json | to_json | b64encode }}"
             - "{{ iroha_all_new_nodes | to_json | b64encode }}"
         register: iroha_command_register
-
+        
+        
       - name: Register new genesis block
         set_fact:
-          iroha_new_genesis_block: "{{ (iroha_command_register.ansible_facts.docker_container.Output | from_json).result }}"
+          iroha_new_genesis_block: "{{ (iroha_command_register.container.Output | from_json).result }}"
 
     delegate_to: "{{ iroha_command_host }}"
     run_once: yes

--- a/ansible/roles/iroha-docker/tasks/manual-keys.yml
+++ b/ansible/roles/iroha-docker/tasks/manual-keys.yml
@@ -71,18 +71,18 @@
     name: "iroha_command_{{ 999999 | random }}"
     image: "{{ iroha_util_docker_image }}"
     recreate: yes
-    detach: no
+    detach: false
     cleanup: yes
-    command:
-      - "gen_keys {{ iroha_invalid_peer_list | length }}"
+    command: "gen_keys {{ iroha_invalid_peer_list | length }}"
   when: iroha_invalid_peer_list | length > 0
   register: iroha_command_register
   delegate_to: "{{ iroha_command_host }}"
   become: yes
 
+
 - name: Attach new peer keys
   set_fact:
-    iroha_new_peer_keys: "{{ iroha_new_peer_keys | combine({item: (iroha_command_register.ansible_facts.docker_container.Output | from_json)['result'][ansible_loop.index0]}, recursive=True) }}"
+    iroha_new_peer_keys: "{{ iroha_new_peer_keys | combine({item: (iroha_command_register.container.Output | from_json)['result'][ansible_loop.index0]}, recursive=True) }}"
   loop: "{{ iroha_invalid_peer_list }}"
   loop_control:
      extended: yes
@@ -106,7 +106,7 @@
 
   - name: Attach encrypt peer keys
     set_fact:
-      iroha_new_peer_keys_encrypt: "{{ (iroha_new_peer_keys_encrypt | default({})) | combine({item.item.key: {'pub': item.item.value.pub, 'priv': '!vault |' + '\n' + (item.ansible_facts.docker_container.Output | from_json)['result'] }}) }}"
+      iroha_new_peer_keys_encrypt: "{{ (iroha_new_peer_keys_encrypt | default({})) | combine({item.item.key: {'pub': item.item.value.pub, 'priv': '!vault |' + '\n' + (item.container.Output | from_json)['result'] }}) }}"
     loop: "{{ iroha_command_register.results}}"
     when: iroha_ansible_vault_key is defined
 


### PR DESCRIPTION
# Task
[DOPS-1451]: Fix iroha-deploy role
depending on version (ansible or docker) Iroha role fails with error:
`iroha_command_register.ansible_facts.docker_container.Output` - is not defined
this is the old name for variable, the new one look like that: `iroha_command_register.container.Output`

## Changes
1. tasks to support new format of the variable  has been fixed
2.  the task to check  that we can run role on new version of Ansible has been added

## Author
Signed-off-by: Vasiliy Zyabkin zyabkin@soramitsu.co.jp