### PR TITLE
Add remove peer in python script

### DIFF
--- a/ansible/roles/iroha-docker/README.md
+++ b/ansible/roles/iroha-docker/README.md
@@ -15,7 +15,7 @@ This method is also suitable for local-only deployments and does not require any
   Tested on Ubuntu 16.04, 18.04
   - Local:
     - python3
-    - ansible(>=2.8)
+    - ansible(>=2.10)
   - Remote:
     - Docker (>=17.12)
     - python3

--- a/ansible/roles/iroha-docker/files/Dockerfile_iroha_python
+++ b/ansible/roles/iroha-docker/files/Dockerfile_iroha_python
@@ -2,7 +2,7 @@ FROM python:3.7-slim-stretch
 
 WORKDIR /opt/app
 
-RUN pip3 install iroha==0.0.5.4 ansible==2.8.3
+RUN pip3 install iroha==1.0.0 ansible==2.10.7
 
 COPY iroha_utils.py iroha_utils.py
 

--- a/ansible/roles/iroha-docker/files/iroha_utils.py
+++ b/ansible/roles/iroha-docker/files/iroha_utils.py
@@ -72,6 +72,12 @@ def add_peer_tx(peer_host, peer_key):
     return tx
 
 
+def remove_peer_tx(peer_key):
+    ir = iroha.Iroha(params['iroha_account'])
+    tx = ir.transaction([ ir.command('RemovePeer', public_key=peer_key) ])
+    iroha.IrohaCrypto.sign_transaction(tx, *params['iroha_account_keys'])
+    return tx
+
 def get_block(block_num):
     ir = iroha.Iroha(params['iroha_account'])
     query = iroha.IrohaCrypto.sign_query(ir.query('GetBlock', height=block_num), params['iroha_account_keys'][0])
@@ -89,6 +95,11 @@ def get_genesis_block():
 
 def add_peer(peer_host, peer_pub_key):
     tx = add_peer_tx(peer_host, peer_pub_key)
+    return(send_transaction(tx))
+
+
+def remove_peer(peer_pub_key):
+    tx = remove_peer_tx(peer_pub_key)
     return(send_transaction(tx))
 
 
@@ -176,6 +187,13 @@ if __name__ == "__main__":
             peer_host = sys.argv[2]
             peer_pub_key = sys.argv[3]
             if add_peer(peer_host, peer_pub_key):
+                exit_and_result(0)
+            else:
+                exit_and_result(1, "Command failed")
+        elif command == 'remove_peer' and len(sys.argv) == 3:
+            init_params()
+            peer_pub_key = sys.argv[2]
+            if remove_peer(peer_pub_key):
                 exit_and_result(0)
             else:
                 exit_and_result(1, "Command failed")


### PR DESCRIPTION
## Changes
In some cases, it is easier to use docker image instead of Iroha cli.I updated the script to be able to run basic tasks.

## Examples
Add peer:
```
docker run -it \
  -e DEBUG=TRUE \
  -e IROHA_HOSTS=10.0.0.3:50051 \
  -e IROHA_ACCOUNT=admin@test  \
  -e IROHA_ACCOUNT_KEYS=f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70 \
  soramitsu/iroha-docker-iroha-python:51a6648 \
   add_peer iroha-5:10001 f715eea67c27d507aee4923c8a7d622d5c1d5a79c0c5a2b7a4c8dcb5d492d912
 ```
 Remove peer
```
docker run -it \
  -e DEBUG=TRUE \
  -e IROHA_HOSTS=10.0.0.3:50051 \
  -e IROHA_ACCOUNT=admin@test  \
  -e IROHA_ACCOUNT_KEYS=f101537e319568c765b2cc89698325604991dca57b9716b58016b253506cab70 \
  soramitsu/iroha-docker-iroha-python:51a6648 \
   remove_peer f715eea67c27d507aee4923c8a7d622d5c1d5a79c0c5a2b7a4c8dcb5d492d912
```
## Author 
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>